### PR TITLE
ci: skip upstream triage workflow in forks

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -16,7 +16,7 @@ jobs:
     name: Auto-triage Pull Request
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: github.event_name == 'pull_request_target'
+    if: github.repository == 'vercel/ai' && github.event_name == 'pull_request_target'
     steps:
       - name: Create access token for GitHub App
         uses: actions/create-github-app-token@v2
@@ -178,7 +178,7 @@ jobs:
     name: Auto-triage Issue
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: github.event_name == 'issues'
+    if: github.repository == 'vercel/ai' && github.event_name == 'issues'
     steps:
       - name: Create access token for GitHub App
         uses: actions/create-github-app-token@v2


### PR DESCRIPTION
## What this does

Guards the upstream Vercel AI SDK triage workflow so it only runs in `vercel/ai`. In the `FlatFilers/ai` fork, the pull request and issue triage jobs will now skip instead of trying to mint a GitHub App token with missing upstream app configuration.

This is CI-only. It does not change package source, runtime code, examples, or docs.

## Why this is needed

Open PRs in this fork currently fail `Auto-triage Pull Request` before the PR diff is relevant. The failure happens in `actions/create-github-app-token@v2` because the fork does not define the upstream app config:

- `vars.VERCEL_AI_SDK_GITHUB_APP_CLIENT_ID` is missing in `FlatFilers/ai`.
- `secrets.VERCEL_AI_SDK_GITHUB_APP_PRIVATE_KEY_PKCS8` is missing or inaccessible.
- The live failure on PR #53 is `Error: [@octokit/auth-app] appId option is required`.

Since the workflow also fetches labels from `/repos/vercel/ai/labels`, this automation is upstream-specific and should not be a required gate in the fork unless the fork intentionally configures its own app.

## How this was proven

- `gh api repos/FlatFilers/ai/actions/variables/VERCEL_AI_SDK_GITHUB_APP_CLIENT_ID` returned `404 Not Found`.
- `gh api repos/FlatFilers/ai/actions/secrets/VERCEL_AI_SDK_GITHUB_APP_PRIVATE_KEY_PKCS8` returned `404 Not Found`.
- `gh run view --repo FlatFilers/ai 25223955283 --job 73962775196 --log` shows `Error: [@octokit/auth-app] appId option is required`.
- `git diff --check` passed.
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/triage.yml"); puts "yaml ok"'` passed.

## Risk / Rollout

Low risk for this fork: it removes a broken upstream-only automation gate. If `FlatFilers/ai` wants triage automation later, it should configure a fork-owned GitHub App and change this guard intentionally.

## Screenshots / Visual Proof

No visual change expected.
